### PR TITLE
Fix: Use wget when installing Gitlab

### DIFF
--- a/mojaloop/iac/roles/gitlab_ci/tasks/main.yaml
+++ b/mojaloop/iac/roles/gitlab_ci/tasks/main.yaml
@@ -6,11 +6,15 @@
     shell: /bin/bash
     state: present
 
-- name: Install GitLab repository
-  get_url:
-    url: https://packages.gitlab.com/install/repositories/runner/gitlab-runner/script.deb.sh
-    dest: /tmp/script.deb.sh
-    mode: 0777
+- name: Download GitLab repository installation script using wget
+  command: wget -O /tmp/script.deb.sh https://packages.gitlab.com/install/repositories/runner/gitlab-runner/script.deb.sh
+  register: wget_output
+  changed_when: "'downloaded' in wget_output.stdout"
+
+- name: Set execute permissions on the downloaded script
+  file:
+    path: /tmp/script.deb.sh
+    mode: '0777'
 
 - name: Run GitLab repository script
   shell: /tmp/script.deb.sh


### PR DESCRIPTION
Refactored Gitlab to use wget (stable on most Linux distribution.